### PR TITLE
Survey tweaks

### DIFF
--- a/home/management/commands/migrate_higher_ed.py
+++ b/home/management/commands/migrate_higher_ed.py
@@ -30,19 +30,19 @@ def scaffold():
   root = Program.objects.get(title='Education Policy')
   # Add Project Page.
   root.add_child(instance=Project(
-    title='HigherEd Public Opinion',
-    slug=slugify('HigherEd Public Opinion'),
-    name='HigherEd Public Opinion',
+    title='HigherEd Public Opinion Hub',
+    slug=slugify('HigherEd Public Opinion Hub'),
+    name='HigherEd Public Opinion Hub',
     template='survey/surveys_home_page.html',
     description='A collection of reports, insights, and analyses exploring topics within Higher Education. Created for Researchers, Journalists,  and the general public who have an interest in underatanding public opinion on Higher Education issues.',
     ))
   # Get Project page and add SurveyHomePage.
-  project = Project.objects.get(title='HigherEd Public Opinion')
-  project.add_child(instance=SurveysHomePage(title='HigherEd Public Opinion Hub'))
+  project = Project.objects.get(title='HigherEd Public Opinion Hub')
+  project.add_child(instance=SurveysHomePage(title='Reports & Insights'))
   # Get SurveyHomePage.
-  home = SurveysHomePage.objects.get(title='HigherEd Public Opinion Hub')
+  home = SurveysHomePage.objects.get(title='Reports & Insights')
   # Get index page.
-  index = SurveyValuesIndex.objects.get(title='HigherEd Public Opinion Hub Values Index')
+  index = SurveyValuesIndex.objects.get(title='Reports & Insights Values Index')
   print(index.id, index.title)
   # Add Demos, Tags, Orgs and Surveys.
   addDemos(index)

--- a/home/management/commands/migrate_higher_ed.py
+++ b/home/management/commands/migrate_higher_ed.py
@@ -65,7 +65,7 @@ def addSurveys(home: SurveysHomePage):
         slug=slug,
         date=date,
         year=survey['Year'],
-        month=0,
+        month=None,
         sample_number=survey['sample_number'],
         data_type = ['QUANT', 'QUAL'],
         findings = survey['Top findings directly from the report'],

--- a/newamericadotorg/api/survey/serializers.py
+++ b/newamericadotorg/api/survey/serializers.py
@@ -1,26 +1,41 @@
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from survey.models import Survey, SurveysHomePage
 from programs.models import Subprogram
+from newamericadotorg.api.author.serializers import AuthorSerializer
+from wagtail.images.views.serve import generate_image_url
 
 class SurveyHomeSerializer(ModelSerializer):
     survey_home_page = SerializerMethodField()
 
     class Meta:
         model = Subprogram
-        fields = ['id', 'title', 'survey_home_page', 'seo_title', 'name', 'url_path']
+        fields = ['id', 'title', 'survey_home_page', 'seo_title', 'name', 'url_path', 'description']
 
     def get_survey_home_page(self, obj):
         return get_survey_homepage(obj)
 
 class SurveysHomePageSerializer(ModelSerializer):
     surveys = SerializerMethodField()
+    page_author = SerializerMethodField()
+    partner_logo = SerializerMethodField()
 
     class Meta:
         model = SurveysHomePage
-        fields = ['id', 'title', 'url_path', 'about', 'methodology', 'page_author', 'surveys']
+        fields = ['id', 'title', 'url_path', 'about', 'methodology', 'page_author', 'surveys', 'partner_logo']
         depth = 1
     def get_surveys(self, obj):
         return get_surveys_detail(obj)
+    
+    def get_page_author(self, obj):
+        authors_rel = obj.authors.all()
+        if not authors_rel:
+            return None
+        authors = [rel.author for rel in authors_rel]
+        return AuthorSerializer(authors, many=True, context=self.context).data
+   
+    def get_partner_logo(self, obj):
+        if obj.partner_logo:
+            return generate_image_url(obj.partner_logo, 'max-240x30')
 
 class SurveyDetailSerializer(ModelSerializer):
 

--- a/newamericadotorg/api/survey/serializers.py
+++ b/newamericadotorg/api/survey/serializers.py
@@ -9,7 +9,7 @@ class SurveyHomeSerializer(ModelSerializer):
 
     class Meta:
         model = Subprogram
-        fields = ['id', 'title', 'survey_home_page', 'seo_title', 'name', 'url_path', 'description']
+        fields = ['id', 'title', 'survey_home_page', 'seo_title', 'name', 'url_path']
 
     def get_survey_home_page(self, obj):
         return get_survey_homepage(obj)
@@ -21,7 +21,7 @@ class SurveysHomePageSerializer(ModelSerializer):
 
     class Meta:
         model = SurveysHomePage
-        fields = ['id', 'title', 'url_path', 'about', 'methodology', 'page_author', 'surveys', 'partner_logo']
+        fields = ['id', 'title', 'url_path', 'about', 'methodology', 'page_author', 'surveys', 'partner_logo', 'subheading']
         depth = 1
     def get_surveys(self, obj):
         return get_surveys_detail(obj)

--- a/newamericadotorg/api/survey/serializers.py
+++ b/newamericadotorg/api/survey/serializers.py
@@ -21,7 +21,7 @@ class SurveysHomePageSerializer(ModelSerializer):
 
     class Meta:
         model = SurveysHomePage
-        fields = ['id', 'title', 'url_path', 'about', 'methodology', 'page_author', 'surveys', 'partner_logo', 'subheading']
+        fields = ['id', 'title', 'url_path', 'about', 'methodology', 'page_author', 'surveys', 'submissions','partner_logo', 'subheading']
         depth = 1
     def get_surveys(self, obj):
         return get_surveys_detail(obj)

--- a/newamericadotorg/assets/react/surveys-homepage/components/AboutTab.js
+++ b/newamericadotorg/assets/react/surveys-homepage/components/AboutTab.js
@@ -16,12 +16,6 @@ const AboutTab = (props) => {
       </a>
     </p>
     `;
-  const logo = `
-    <img
-      src="https://www.gavi.org/sites/default/files/investing/funding/donor-contributions-pledges/bmgf-topspace2.png"
-      alt=""
-    />
-  `;
 
   return (
     <div className="surveys-about-tab">
@@ -30,8 +24,13 @@ const AboutTab = (props) => {
         body={survey_home_page.about}
       />
       <Body title="Methodology" body={survey_home_page.methodology} />
-      <Body title="Submit a Report" body={submitReport} />
-      <Body title="Made Possible By" body={logo} />
+      <Body
+        title="Submit a Report"
+        body={survey_home_page.submissions}
+      />
+      <Body title="Made Possible By" body="">
+        <img src={survey_home_page.partner_logo} alt="Partner" />
+      </Body>
       <Body title="Authors" body="">
         <Authors authors={survey_home_page.page_author} md={true} />
       </Body>

--- a/newamericadotorg/assets/react/surveys-homepage/components/BasicHeader.js
+++ b/newamericadotorg/assets/react/surveys-homepage/components/BasicHeader.js
@@ -15,8 +15,7 @@ const BasicHeader = (props) => {
           {data.title || 'HigherEd Polling Dashboard'}
         </h1>
         <h6 className="basic-header__subtitle margin-top-25 margin-bottom-0">
-          {data.description ||
-            'A collection of reports, insights, and analyses exploring topics within Higher Education. Created for Researchers, Journalists, and the general public who have an interest understanding public opinion on Higher Education issues.'}
+          {data.survey_home_page.subheading}
         </h6>
       </div>
     </div>

--- a/newamericadotorg/assets/react/surveys-homepage/components/CheckboxGroup.js
+++ b/newamericadotorg/assets/react/surveys-homepage/components/CheckboxGroup.js
@@ -30,13 +30,9 @@ class CheckboxGroup extends React.Component {
   render() {
     const { isOpen } = this.state;
     const { options, title } = this.props;
-    const _options = options
-      .filter((item) => {
-        return item.id !== 'isOpen';
-      })
-      .sort((a, b) => {
-        return a.label.localeCompare(b.label);
-      });
+    const _options = options.filter((item) => {
+      return item.id !== 'isOpen';
+    });
 
     return (
       <div

--- a/newamericadotorg/assets/react/surveys-homepage/components/CheckboxGroup.scss
+++ b/newamericadotorg/assets/react/surveys-homepage/components/CheckboxGroup.scss
@@ -9,11 +9,6 @@
 .checkbox-group {
   border-bottom: 1px solid color(black, base, 0.3);
   padding: 24px 0;
-  overflow-x: hidden;
-  &--is-open {
-    overflow-y: scroll;
-    max-height: 425px;
-  }
 
   &__title {
     display: flex;
@@ -27,8 +22,9 @@
     max-height: 0;
     overflow-y: hidden;
     &.is-open {
-      max-height: none;
       animation: fadeIn 0.3s ease-in;
+      overflow-y: scroll;
+      max-height: 332.7px;
     }
   }
   &__option {

--- a/newamericadotorg/assets/react/surveys-homepage/components/SurveysTab.js
+++ b/newamericadotorg/assets/react/surveys-homepage/components/SurveysTab.js
@@ -122,11 +122,15 @@ class SurveysTab extends React.Component {
           >
             <CheckboxGroup
               title="Topic"
-              options={Object.keys(tags).map((tag) => ({
-                id: tag,
-                checked: false,
-                label: tag.charAt(0).toUpperCase() + tag.slice(1),
-              }))}
+              options={Object.keys(tags)
+                .map((tag) => ({
+                  id: tag,
+                  checked: false,
+                  label: tag.charAt(0).toUpperCase() + tag.slice(1),
+                }))
+                .sort((a, b) => {
+                  return a.label.localeCompare(b.label);
+                })}
               onChange={(filterState) =>
                 this.onFilterChange('tags', filterState)
               }
@@ -134,11 +138,15 @@ class SurveysTab extends React.Component {
 
             <CheckboxGroup
               title="Demographic"
-              options={Object.keys(demos).map((demo) => ({
-                id: demo,
-                checked: false,
-                label: demo.charAt(0).toUpperCase() + demo.slice(1),
-              }))}
+              options={Object.keys(demos)
+                .map((demo) => ({
+                  id: demo,
+                  checked: false,
+                  label: demo.charAt(0).toUpperCase() + demo.slice(1),
+                }))
+                .sort((a, b) => {
+                  return a.label.localeCompare(b.label);
+                })}
               onChange={(filterState) =>
                 this.onFilterChange('demos', filterState)
               }
@@ -198,11 +206,15 @@ class SurveysTab extends React.Component {
             />
             <CheckboxGroup
               title="Organization"
-              options={Object.keys(orgs).map((org) => ({
-                id: org,
-                checked: false,
-                label: org.charAt(0).toUpperCase() + org.slice(1),
-              }))}
+              options={Object.keys(orgs)
+                .map((org) => ({
+                  id: org,
+                  checked: false,
+                  label: org.charAt(0).toUpperCase() + org.slice(1),
+                }))
+                .sort((a, b) => {
+                  return a.label.localeCompare(b.label);
+                })}
               onChange={(filterState) =>
                 this.onFilterChange('orgs', filterState)
               }

--- a/newamericadotorg/assets/react/surveys-homepage/components/TeaserListing.js
+++ b/newamericadotorg/assets/react/surveys-homepage/components/TeaserListing.js
@@ -1,7 +1,7 @@
 import './TeaserListing.scss';
 import React, { Component } from 'react';
 import { differenceInMonths } from 'date-fns/esm';
-import { format } from 'date-fns';
+import moment from 'moment';
 import { LoadingDots } from '../../components/Icons';
 
 class TeaserListing extends Component {
@@ -91,9 +91,10 @@ class TeaserListing extends Component {
       })
       .filter((val) => {
         const { dateRange } = checkedValues;
+        const month = moment().month(val['month']).format('M');
         const monthDiff = differenceInMonths(
           new Date(),
-          new Date(val['year'], val['month'], 0)
+          new Date(val['year'], month, 0)
         );
 
         const unfilter = Object.keys(dateRange).every(function (k) {
@@ -183,25 +184,21 @@ class TeaserListing extends Component {
         return false;
       })
       .filter((row) => {
-        if (row.month) {
-          row.monthString = format(
-            new Date(row.year, row.month - 1, 1),
-            'MMM'
-          );
-        }
         const columns = Object.keys(row).filter((item) => {
           if (
             item === 'title' ||
             item === 'description' ||
             item === 'year' ||
-            item === 'monthString'
+            item === 'month'
           ) {
             return true;
           }
         });
 
-        return columns.some((column) =>
-          row[column] !== null && row[column].toString().toLowerCase().includes(searchTerm)
+        return columns.some(
+          (column) =>
+            row[column] !== null &&
+            row[column].toString().toLowerCase().includes(searchTerm)
         );
       })
       .sort((a, b) => {
@@ -276,10 +273,7 @@ class TeaserListing extends Component {
                 )}
               </div>
               <div className="col-sm-3 teaser-listing__item-date">
-                {format(
-                  new Date(item.year, item.month && item.month -1, 1),
-                  item.month ? 'MMM yyyy' : 'yyy'
-                )}
+                {item.month} {item.year}
               </div>
             </a>
           ))}

--- a/survey/models.py
+++ b/survey/models.py
@@ -143,7 +143,7 @@ class Survey(Post):
     description = models.CharField(blank=True, null=True, max_length=500, help_text='A brief description of the survey. 500 chars max')
     org = ParentalManyToManyField('SurveyOrganization', related_name='SurveyOrganization', blank=True, verbose_name='Organization')
     year = models.IntegerField(help_text='Year Survey was conducted.', blank=True, default=2000)
-    month = models.IntegerField(choices=MONTH_CHOICES, default=None, help_text='Month Survey was conducted, if applicable.')
+    month = models.CharField(choices=MONTH_CHOICES, default=None, help_text='Month Survey was conducted, if applicable.', max_length=3, blank=True, null=True)
     sample_number = models.IntegerField(blank=True, null=True)
     demos_key = ParentalManyToManyField('DemographicKey', help_text='Indexable demographic groups', blank=True, default=False, verbose_name='Demographics Keys')
     findings = RichTextField(blank=True, null=True, max_length=12500)

--- a/survey/models.py
+++ b/survey/models.py
@@ -58,13 +58,14 @@ class SurveysHomePage(AbstractContentPage):
     )
     subheading = models.CharField(max_length=200, blank=True)
     methodology = RichTextField(max_length = 1500, blank=True)
-
+    submissions = RichTextField(blank=True, null=True, max_length=500)
     content_panels = [
       FieldPanel('title'),
       FieldPanel('subheading'),
       MultiFieldPanel([
         FieldPanel('about'),
         FieldPanel('methodology'),
+        FieldPanel('submissions'),
         InlinePanel('authors', label="Authors"),
         ImageChooserPanel('partner_logo'),
       ], heading='About Page')

--- a/survey/models.py
+++ b/survey/models.py
@@ -140,7 +140,7 @@ class Survey(Post):
     template = 'survey/survey.html' 
     parent_page_types = ['SurveysHomePage']
 
-    description = RichTextField(blank=True, null=True, max_length=500, help_text='A brief description of the survey. 500 chars max')
+    description = models.CharField(blank=True, null=True, max_length=500, help_text='A brief description of the survey. 500 chars max')
     org = ParentalManyToManyField('SurveyOrganization', related_name='SurveyOrganization', blank=True, verbose_name='Organization')
     year = models.IntegerField(help_text='Year Survey was conducted.', blank=True, default=2000)
     month = models.IntegerField(choices=MONTH_CHOICES, default=None, help_text='Month Survey was conducted, if applicable.')
@@ -176,6 +176,11 @@ class Survey(Post):
         FieldPanel('file')
       ])
     ]
+    class Meta:
+      verbose_name = 'Survey Reports'
+
+    def __str__(self):
+        return self.title
 
 class Commentary(Post):
   template = 'survey/commentary.html'

--- a/survey/templates/survey/commentary.html
+++ b/survey/templates/survey/commentary.html
@@ -5,7 +5,13 @@
 
 {% block content %}
   {% block breadcrumbs %}
-    {% include 'components/breadcrumbs.html' %}
+    {% with a=self.get_ancestors %}
+      <div class="container margin-top-25 breadcrumb">
+        <h6 class="link with-caret--left">
+          <a href="{{ a.3.url }}"><u>{{a.3.title}}</u></a>
+        </h6>
+      </div>
+    {% endwith %}
   {% endblock %}
   {% include 'components/post_main.html' %}
 

--- a/survey/templates/survey/survey.html
+++ b/survey/templates/survey/survey.html
@@ -6,10 +6,15 @@
 
 {% block body_id %}na-survey{% endblock %}
 
-
 {% block content %}
   {% block breadcrumbs %}
-    {% include 'components/breadcrumbs.html' %}
+    {% with a=self.get_ancestors %}
+      <div class="container margin-top-25 breadcrumb">
+        <h6 class="link with-caret--left">
+          <a href="{{ a.3.url }}"><u>{{a.3.title}}</u></a>
+        </h6>
+      </div>
+    {% endwith %}
   {% endblock %}
   <main class="survey-page container margin-35 margin-lg-80">
     <div class="row gutter-30">
@@ -59,7 +64,7 @@
                 <span>Sample Size:</span>
                 {{ page.sample_number }}
               </div>
-              <div class="">
+              <div class="margin-bottom-15">
                 {% with demos=page.demos_key.all %}
                   {% if demos %}
                     <span>Demographics:&nbsp;</span>
@@ -68,7 +73,7 @@
                       {% if forloop.counter == demos|length|add:"-1" and demos|length > 2 %}
                         <span class="separator inline">, and&nbsp;</span>
                         {% elif forloop.counter == demos|length|add:"-1" %}
-                        <span class="inline">&nbspand&nbsp;</span>
+                        <span class="separator inline">&nbspand&nbsp;</span>
                         {% elif forloop.counter != demos|length %}
                         <span class="separator inline">,&nbsp;</span>
                       {% endif %}
@@ -76,6 +81,23 @@
                   {% endif %}
                 {% endwith %}
               </div>
+              {% with tags=page.tags.all %}
+                {% if tags %}
+                  <div class="margin-bottom-15">
+                    <span>Topics:&nbsp;</span>
+                    {% for tag in tags %}
+                      {{ tag.title }}
+                      {% if forloop.counter == tags|length|add:"-1" and tags|length > 2 %}
+                        <span class="separator inline">, and&nbsp;</span>
+                      {% elif forloop.counter == tags|length|add:"-1" %}
+                        <span class="separator inline">&nbspand&nbsp;</span>
+                      {% elif forloop.counter != tags|length %}
+                        <span class="separator inline">,&nbsp;</span>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              {% endwith %}
             </div>
 
             <div class="margin-bottom-35">
@@ -120,7 +142,7 @@
                             {{ item.date|date:"M. jS, Y"}}
                           </h6>
                           <h4 class="card__text__title margin-top-0 margin-bottom-10">
-                            <a href="{{ item.url }}" class="">
+                            <a href="{{ item.url }}" class="" target="_blank">
                             <u>{{ item.title }}</u>
                             </a>
                           </h4>

--- a/survey/utils.py
+++ b/survey/utils.py
@@ -1,17 +1,17 @@
 MONTH_CHOICES = (
-  (0, 'N/A'),
-  (1, 'January'),
-  (2, 'February'),
-  (3, 'March'),
-  (4, 'April'),
-  (5, 'May'),
-  (6, 'June'),
-  (7, 'July'),
-  (8, 'August'),
-  (9, 'September'),
-  (10, 'October'),
-  (11, 'November'),
-  (12, 'December')
+  ('N/A', 'N/A'),
+  ('Jan', 'January'),
+  ('Feb', 'February'),
+  ('Mar', 'March'),
+  ('Apr', 'April'),
+  ('May', 'May'),
+  ('Jun', 'June'),
+  ('Jul', 'July'),
+  ('Aug', 'August'),
+  ('Sep', 'September'),
+  ('Oct', 'October'),
+  ('Nov', 'November'),
+  ('Dec', 'December')
 )
 
 DATA_TYPE_CHOICES = (

--- a/survey/utils.py
+++ b/survey/utils.py
@@ -1,5 +1,5 @@
 MONTH_CHOICES = (
-  ('N/A', 'N/A'),
+  (None, 'N/A'),
   ('Jan', 'January'),
   ('Feb', 'February'),
   ('Mar', 'March'),


### PR DESCRIPTION
PR reflects work outlined in NAHE-19,20,22,30

Adds:

- Submissions filed ro homepage
- Rename pages generated by migration to reflect docs
- Change month and description to Charfields
- Update MONTH_CHOICES util to match changes.
- Add verbose name of "Survey Reports" to survey model.
- Expose author and partner logo img src in api. 